### PR TITLE
Add futex based interrupt mode

### DIFF
--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -23,6 +23,14 @@ int main(int argc, char** argv)
 		{
 			puts("Failed to write.");
 		}
+//#define INTERUPT_MODE
+#ifdef INTERUPT_MODE
+		else
+		{
+			spsc_wake_reader(&ring);
+		}
+#endif /* INTERUPT_MODE */
+
 		puts("Enter text: ");
 	}
 

--- a/examples/subscriber.c
+++ b/examples/subscriber.c
@@ -19,6 +19,14 @@ int main(int argc, char** argv)
 	char buf[256];
 	while (1)
 	{
+//#define INTERUPT_MODE
+#ifdef INTERUPT_MODE
+		/* FUTEX based interupt mode, otherwise subscriber busy-waits.
+		 * NOTE: Must be enabled on both subscriber and publisher side.
+		 */
+		spsc_wait_for_data(&ring);
+#endif /* INTERUPT_MODE */
+
 		size_t n_read = spsc_read(&ring, buf, 255); 
 		if (n_read > 0)
 		{

--- a/lib/spsc.h
+++ b/lib/spsc.h
@@ -24,6 +24,9 @@ typedef struct spsc_ring_data
 	size_t _wpos;
 	char __pad2[64];
 
+	int _futex_word;
+	char __pad3[64];
+
 	char _buf[];
 } spsc_ring_data;
 
@@ -81,6 +84,20 @@ size_t spsc_read(spsc_ring* ring, void* dest, const size_t n);
  * @return the number of bytes copied, or 0 if the ring is full.
  */
 MSG_SIZE_T spsc_write(spsc_ring* ring, const void* src, const MSG_SIZE_T n);
+
+/**
+ * Wait until data occur in the ring (interupt mode, reader side).
+ * @param ring pointer to a spsc_ring structure
+ * @return 0 if successful, otherwise an error code is returned.
+ */
+int spsc_wait_for_data(spsc_ring* ring);
+
+/**
+ * Signalize to reader that the data has been sent (interupt mode, writer side).
+ * @param ring pointer to a spsc_ring structure
+ * @return 0 if successful, otherwise an error code is returned.
+ */
+int spsc_wake_reader(spsc_ring* ring);
 
 /**
  * Gets an approximate size of the ring. The returned number depends on whether the publishing thread or subscribing thread called the method. The behvaiour is undefined for any other calling thread.


### PR DESCRIPTION
This adds interrupt mode mechanism, i.e. to be able to avoid busy wait on reader side.
If used, user code can wait for "data present" event, signaling is internally done using FUTEX, the fastest Linux synchronization method.
If not used, it has no performance impact.